### PR TITLE
Removal of Obsolete Rule in sepolicy: Compilation Error Fix

### DIFF
--- a/sepolicy/vendor/hal_power_default.te
+++ b/sepolicy/vendor/hal_power_default.te
@@ -3,9 +3,6 @@ typeattribute hal_power_default mlstrustedsubject;
 allow hal_power_default sysfs_devices_system_cpu:file rw_file_perms;
 allow hal_power_default cgroup:file r_file_perms;
 
-# To get/set powerhal state property
-set_prop(hal_power_default, vendor_power_prop)
-
 # Rule for hal_power_default to access graphics composer process
 unix_socket_connect(hal_power_default, pps, hal_graphics_composer_default);
 


### PR DESCRIPTION
This PR addresses an issue where, in commit https://github.com/selene-devs/android_device_xiaomi_selene/commit/e250fbdb6ae07bedad22229ddec23b6594e8ed57, a cleanup was performed in sepolicy but an obsolete rule was forgotten to be removed, causing compilation errors. This rule was added in commit https://github.com/selene-devs/android_device_xiaomi_selene/commit/deb636b463f296467163569236b6ab2f40080113 and removed in commit e250fbd.

Additionally, an additional compilation error message is observed:

[ 58% 92486/157104] //system/sepolicy:recovery_sepolicy.cil Building cil for recovery_sepolicy.cil [common] FAILED: out/soong/.intermediates/system/sepolicy/recovery_sepolicy.cil/android_common/recovery_sepolicy.cil out/host/linux-x86/bin/checkpolicy -C -M -c 30 -o out/soong/.intermediates/system/sepolicy/recovery_sepolicy.cil/android_common/recovery_sepolicy.cil out/soong/.intermediates/system/sepolicy/recovery_sepolicy.conf/android_common/recovery_ sepolicy.conf # hash of input list: a316674d1dc0868a105f79e687a4b6449e6a8801cfa3253b9c426787c1c40d09 device/xiaomi/selene/sepolicy/vendor/hal_power_default.te:7:ERROR 'unknown type vendor_power_prop' at token ';' on line 94779: #line 7
allow hal_power_default vendor_power_prop:property_service set; checkpolicy:  error(s) encountered while parsing configuration 12:25:52 ninja failed with: exit status 1

Changes:
- The obsolete 'set_prop' rule was removed from the 'hal_power_default.te' file.

This correction should resolve the compilation error that occurred due to the obsolete rule.